### PR TITLE
`filtersmeta` from kwargs did not get applied

### DIFF
--- a/caterva/caterva_ext.pyx
+++ b/caterva/caterva_ext.pyx
@@ -246,7 +246,7 @@ cdef class Context:
 
         filtersmeta = kwargs.get('filtersmeta', config_dflts['filtersmeta'])
         for i in range(BLOSC2_MAX_FILTERS - len(filtersmeta), BLOSC2_MAX_FILTERS):
-            self.filtersmeta[i] = filtersmeta[i - BLOSC2_MAX_FILTERS + len(filtersmeta)]
+            config.filtersmeta[i] = filtersmeta[i - BLOSC2_MAX_FILTERS + len(filtersmeta)]
 
         caterva_ctx_new(&config, &self.context_)
 


### PR DESCRIPTION
I was testing some compression ratios and noticed that `filtersmeta` from kwargs did not get applied correctly

```python
c = caterva.from_buffer(data.tobytes(), data.shape, 4, chunks=[1, 1000, 1000], blocks=[1, 1000, 1000], filters=[caterva.Filter.TRUNC_PREC, caterva.Filter.BITSHUFFLE], filtersmeta=[16, 0])
```

prints `The precision needs to be at least 1 bit`

This PR corrects that `filtersmeta` gets applied correctly